### PR TITLE
Fix create_csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ## rsoi v0.5.1
 * Reverts El Nino/ La Nina mixup (Thanks to Arthur Chapman for the email submitted patch)
 * Remove rpdo and devtools from Suggests
+* Fix bug in `download_enso()`'s ability to save data to .csv
 
 ## rsoi v0.5.0
 * Checks if internet is installed

--- a/R/download-enso.R
+++ b/R/download-enso.R
@@ -54,11 +54,6 @@ download_enso <- function(climate_idx = c("all", "soi", "oni","npgo"), create_cs
     return(npgo_df)
   }
   
-  if(create_csv==TRUE){
-    write.csv(enso, "ENSO_Index.csv")
-  }
-  
-  
   if(climate_idx[1] == "all"){
   ## Join index data
     oni_df = download_oni()
@@ -67,6 +62,11 @@ download_enso <- function(climate_idx = c("all", "soi", "oni","npgo"), create_cs
     enso <- merge(oni_df, soi_df)
     enso <- merge(enso, npgo_df)
     enso <- enso[,c("Date", "Year", "Month", "ONI", "phase", "SOI", "NPGO")]
+    
+    
+    if(create_csv == TRUE){
+      write.csv(enso, "ENSO_Index.csv")
+    }
     
     class(enso) <- c("tbl_df", "tbl", "data.frame") 
     return(enso)

--- a/tests/testthat/test_download_enso.R
+++ b/tests/testthat/test_download_enso.R
@@ -5,3 +5,15 @@ test_that("Does download_enso() download a data.frame?", {
   skip_if_shutdown()
   expect_is( download_enso(), "data.frame" )
 })
+
+
+test_that("Does download_enso() save to a file?", {
+  skip_if_no_internet()
+  skip_if_shutdown()
+  
+  old <- setwd(tempdir())
+  on.exit(setwd(old))
+  expect_is(download_enso(create_csv = TRUE), "data.frame" )
+  expect_true(file.exists("ENSO_Index.csv"))
+  setwd(old)
+})


### PR DESCRIPTION
The  `create_csv()` argument doesn't seem to work. 

``` r
rsoi::download_enso(create_csv = TRUE)
#> Error in is.data.frame(x): object 'enso' not found
```

The problem is that `download_enso()` tried to save it before it was loaded. This fixes the issue. 