### PR TITLE
Fixes `abbr_month()` locale problem

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Reverts El Nino/ La Nina mixup (Thanks to Arthur Chapman for the email submitted patch)
 * Remove rpdo and devtools from Suggests
 * Fix bug in `download_enso()`'s ability to save data to .csv
+* Download functions respect machine locale. 
 
 ## rsoi v0.5.0
 * Checks if internet is installed

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,10 +3,11 @@
 abbr_month <- function(date){
   if(class(date) != "Date") stop("Not a date object", call. = FALSE)
   
+  levels <- format(seq(as.Date("2018-01-01"), as.Date("2018-12-01"), "1 month"), "%b")
+  
   factor(format(date, "%b"),
          ordered = TRUE,
-         levels = c("Jan", "Feb", "Mar", "Apr", "May", 
-                    "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"))
+         levels = levels)
 }
 
 ## Check the response from server.


### PR DESCRIPTION
Now every download function returns all `NA`s in the `month` column. Hilariously, `download_oni()` also returns a `ONI_month_window` with is filled with "NANANA" (BATMAAAAN!! :laughing: )

This is due to the `abbr_month()` function, which has hard-coded levels in English. This fix created the levels using the default locale. With this fix, you get months with the correct locale:

``` r
head(rsoi::download_ao())
#>   Year Month     AO
#> 1 1950   ene -0.060
#> 2 1950   feb  0.627
#> 3 1950   mar -0.008
#> 4 1950   abr  0.555
#> 5 1950   may  0.072
#> 6 1950   jun  0.539
```

<sup>Created on 2019-10-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
