### PR TITLE
Adds cache to `download_oni()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     memoise,
     readr
 Suggests:
-    testthat,
+    testthat (>= 2.1.0),
     tibble
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ Depends:
 Imports:
     curl,
     stats,
-    memoise,
-    readr
+    memoise
 Suggests:
     testthat (>= 2.1.0),
     tibble

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,12 @@ Depends:
     R (>= 3.3.0)
 Imports:
     curl,
-    stats
+    stats,
+    memoise,
+    readr
 Suggests:
     testthat,
     tibble
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Remove rpdo and devtools from Suggests
 * Fix bug in `download_enso()`'s ability to save data to .csv
 * Download functions respect machine locale. 
+* Download functions can optionally cache data to memory or disk. 
 
 ## rsoi v0.5.0
 * Checks if internet is installed

--- a/R/download-ao.R
+++ b/R/download-ao.R
@@ -52,13 +52,12 @@ download_ao_unmemoised <- function(){
 download_ao_memoised <- memoise::memoise(download_ao_unmemoised)
 
 
-
 # Function to read oni data from file. 
 read_ao <- function(file) {
   data <- read.csv(file)
-  data$Date <- as.Date(data$Date)
-  data$Month <- abbr_month(data$Date)
-  
+  data$Year <- as.character(data$Year)
+  levels <- format(seq(as.Date("2018-01-01"), as.Date("2018-12-01"), "1 month"), "%b")
+  data$Month <- factor(data$Month, levels = levels, ordered = TRUE)
   class(data) <- c("tbl_df", "tbl", "data.frame")
   data
 }

--- a/R/download-ao.R
+++ b/R/download-ao.R
@@ -1,6 +1,7 @@
 #' @export
 #' @title Download North Atlantic Oscillation data
 #' 
+#' @inheritParams download_oni
 #' 
 #' @description surface sea-level pressure difference between the Subtropical (Azores) High and the Subpolar Low. 
 #' @return 
@@ -16,16 +17,16 @@
 #' }
 #'
 #' @references \url{https://www.ncdc.noaa.gov/teleconnections/nao}
-
+download_ao <- function(use_cache = FALSE, file = NULL) {
+  with_cache(use_cache = use_cache, file = file, 
+             memoised = download_ao_memoised, 
+             unmemoised = download_ao_unmemoised, 
+             read_function = read_ao)
+}
 
 
 ## Function to download ONI data
-download_ao <- function(){
-  
-  if(!curl::has_internet()){
-    return(message("A working internet connection is required to download and import the climate indices."))
-  }
-  
+download_ao_unmemoised <- function(){
   ao_link ="https://www.ncdc.noaa.gov/teleconnections/ao/data.csv"
   
   res = check_response(ao_link)
@@ -46,4 +47,18 @@ download_ao <- function(){
   
   ao[,c("Year","Month", "AO")]
   
+}
+
+download_ao_memoised <- memoise::memoise(download_ao_unmemoised)
+
+
+
+# Function to read oni data from file. 
+read_ao <- function(file) {
+  data <- read.csv(file)
+  data$Date <- as.Date(data$Date)
+  data$Month <- abbr_month(data$Date)
+  
+  class(data) <- c("tbl_df", "tbl", "data.frame")
+  data
 }

--- a/R/download-nao.R
+++ b/R/download-nao.R
@@ -55,9 +55,9 @@ download_nao_memoised <- memoise::memoise(download_nao_unmemoised)
 
 read_nao <- function(file) {
   data <- read.csv(file)
-  data$Date <- as.Date(data$Date)
-  data$Month <- abbr_month(data$Date)
-  
+  data$Year <- as.character(data$Year)
+  levels <- format(seq(as.Date("2018-01-01"), as.Date("2018-12-01"), "1 month"), "%b")
+  data$Month <- factor(data$Month, levels = levels, ordered = TRUE)
   class(data) <- c("tbl_df", "tbl", "data.frame")
   data
 }

--- a/R/download-nao.R
+++ b/R/download-nao.R
@@ -1,6 +1,7 @@
 #' @export
 #' @title Download North Atlantic Oscillation data
 #' 
+#' @inheritParams download_oni
 #' 
 #' @description surface sea-level pressure difference between the Subtropical (Azores) High and the Subpolar Low. 
 #' @return 
@@ -17,15 +18,15 @@
 #'
 #' @references \url{https://www.ncdc.noaa.gov/teleconnections/nao}
 
-
+download_nao <- function(use_cache = FALSE, file = NULL) {
+  with_cache(use_cache = use_cache, file = file, 
+             memoised = download_nao_memoised, 
+             unmemoised = download_nao_unmemoised, 
+             read_function = read_nao)
+}
 
 ## Function to download ONI data
-download_nao <- function(){
-  
-  if(!curl::has_internet()){
-    return(message("A working internet connection is required to download and import the climate indices."))
-  }
-  
+download_nao_unmemoised <- function(){
   nao_link ="https://www.ncdc.noaa.gov/teleconnections/nao/data.csv"
   
   res <- check_response(nao_link)
@@ -47,4 +48,16 @@ download_nao <- function(){
   nao[,c("Year","Month", "NAO")]
   
   
+}
+
+download_nao_memoised <- memoise::memoise(download_nao_unmemoised)
+
+
+read_nao <- function(file) {
+  data <- read.csv(file)
+  data$Date <- as.Date(data$Date)
+  data$Month <- abbr_month(data$Date)
+  
+  class(data) <- c("tbl_df", "tbl", "data.frame")
+  data
 }

--- a/R/download-npgo.R
+++ b/R/download-npgo.R
@@ -4,6 +4,8 @@
 #' 
 #' @description North Pacific Gyre Oscillation data also known as the Victoria mode
 #' 
+#' @inheritParams download_oni
+#' 
 #' @return 
 #' \itemize{
 #' \item Date: Date object that uses the first of the month as a placeholder. Date formatted as date on the first of the month because R only supports one partial of date time
@@ -17,14 +19,16 @@
 #' }
 #'
 #' @references \url{http://www.oces.us/npgo} 
+download_npgo <- function(use_cache = FALSE, file = NULL) {
+  with_cache(use_cache = use_cache, file = file, 
+             memoised = download_npgo_memoised, 
+             unmemoised = download_npgo_unmemoised, 
+             read_function = read_npgo)
+}
 
 
-download_npgo <- function() {
-  
-  if(!curl::has_internet()){
-    return(message("A working internet connection is required to download and import the climate indices."))
-  }
-  
+
+download_npgo_unmemoised <- function() {
   npgo_link ="http://www.oces.us/npgo/data/NPGO.txt"
   
   res = check_response(npgo_link)
@@ -40,7 +44,18 @@ download_npgo <- function() {
   npgo$Month = abbr_month(npgo$Date)
 
   class(npgo) <- c("tbl_df", "tbl", "data.frame") 
-  
-  npgo[,c("Date","Year", "Month", "NPGO")]
+  npgo[, c("Date","Year", "Month", "NPGO")]
+}
 
+download_npgo_memoised <- memoise::memoise(download_npgo_unmemoised)
+
+
+read_npgo <- function(file) {
+  data <- read.csv(file)
+  data$Date <- as.Date(data$Date)
+  data$Month <- abbr_month(data$Date)
+  data$Year <- as.double(data$Year)
+  
+  class(data) <- c("tbl_df", "tbl", "data.frame")
+  data
 }

--- a/R/download-oni.R
+++ b/R/download-oni.R
@@ -37,33 +37,6 @@ download_oni <-  function(cache = FALSE, file = NULL) {
 }
 
 
-with_cache <- function(cache, file, memoised, unmemoised) {
-  # cache in memory
-  if (cache && is.null(file)) {
-    return(memoised())
-  }
-  
-  # cache in file  
-  if (cache && file.exists(file)) {
-    return(suppressMessages(readr::read_csv(file)))
-  }
-  
-  if(!curl::has_internet()){
-    message("A working internet connection is required to download and import the climate indices.")
-    return(NULL)
-  }
-  data <- unmemoised()
-  
-  if (!is.null(file)) { 
-    readr::write_csv(data, file)
-  }
-  
-  if (!cache) {
-    memoise::forget(memoised)
-  } 
-  
-  return(data)
-}
 
 ## Function to download ONI data
 download_oni_unmemoised <- function() {

--- a/R/download-oni.R
+++ b/R/download-oni.R
@@ -31,7 +31,7 @@
 #' @references \url{http://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt}
 
 download_oni <-  function(use_cache = FALSE, file = NULL) {
-  with_cache(cache = cache, file = file, 
+  with_cache(use_cache = use_cache, file = file, 
              memoised = download_oni_memoised, 
              unmemoised = download_oni_unmemoised, 
              read_function = read_oni)
@@ -86,4 +86,5 @@ read_oni <- function(file) {
   data$ONI_month_window <- as.character(data$ONI_month_window)
   
   class(data) <- c("tbl_df", "tbl", "data.frame")
+  data
 }

--- a/R/download-oni.R
+++ b/R/download-oni.R
@@ -1,6 +1,10 @@
 #' @export
 #' @title Download Oceanic Nino Index data
 #' 
+#' @param cache logical option to save and load from cache. If `TRUE`, results will be cached in memory
+#' if `file` is `NULL` or on disk if `file` is not `NULL`.
+#' @param file optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+#' `file` is not `NULL`, the results will be downloaded from the internet and saved on disk. 
 #' 
 #' @description The Oceanic Nino Index is average sea surface temperature in the Nino 3.4 region (120W to 170W) averaged over three months. Phases are categorized by Oceanic Nino Index:
 #' \itemize{
@@ -26,15 +30,43 @@
 #'
 #' @references \url{http://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt}
 
+download_oni <-  function(cache = FALSE, file = NULL) {
+  with_cache(cache = cache, file = file, 
+             memoised = download_oni_memoised, 
+             unmemoised = download_oni_unmemoised)
+}
 
 
-## Function to download ONI data
-download_oni <- function(){
+with_cache <- function(cache, file, memoised, unmemoised) {
+  # cache in memory
+  if (cache && is.null(file)) {
+    return(memoised())
+  }
+  
+  # cache in file  
+  if (cache && file.exists(file)) {
+    return(suppressMessages(readr::read_csv(file)))
+  }
   
   if(!curl::has_internet()){
-    return(message("A working internet connection is required to download and import the climate indices."))
+    message("A working internet connection is required to download and import the climate indices.")
+    return(NULL)
   }
+  data <- unmemoised()
+  
+  if (!is.null(file)) { 
+    readr::write_csv(data, file)
+  }
+  
+  if (!cache) {
+    memoise::forget(memoised)
+  } 
+  
+  return(data)
+}
 
+## Function to download ONI data
+download_oni_unmemoised <- function() {
   oni_link ="http://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt"
   
   res = check_response(oni_link)
@@ -67,7 +99,6 @@ download_oni <- function(){
   class(oni) <- c("tbl_df", "tbl", "data.frame") 
   
   oni[,c("Date", "Month", "Year","dSST3.4", "ONI", "ONI_month_window", "phase")]
-  
-  
-  
 }
+
+download_oni_memoised <- memoise::memoise(download_oni_unmemoised)

--- a/R/download-oni.R
+++ b/R/download-oni.R
@@ -1,7 +1,7 @@
 #' @export
 #' @title Download Oceanic Nino Index data
 #' 
-#' @param cache logical option to save and load from cache. If `TRUE`, results will be cached in memory
+#' @param use_cache logical option to save and load from cache. If `TRUE`, results will be cached in memory
 #' if `file` is `NULL` or on disk if `file` is not `NULL`.
 #' @param file optional character with the full path of a file to save the data. If `cache` is `FALSE` but
 #' `file` is not `NULL`, the results will be downloaded from the internet and saved on disk. 
@@ -30,10 +30,11 @@
 #'
 #' @references \url{http://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/detrend.nino34.ascii.txt}
 
-download_oni <-  function(cache = FALSE, file = NULL) {
+download_oni <-  function(use_cache = FALSE, file = NULL) {
   with_cache(cache = cache, file = file, 
              memoised = download_oni_memoised, 
-             unmemoised = download_oni_unmemoised)
+             unmemoised = download_oni_unmemoised, 
+             read_function = read_oni)
 }
 
 
@@ -74,4 +75,15 @@ download_oni_unmemoised <- function() {
   oni[,c("Date", "Month", "Year","dSST3.4", "ONI", "ONI_month_window", "phase")]
 }
 
+# Memoised function
 download_oni_memoised <- memoise::memoise(download_oni_unmemoised)
+
+# Function to read oni data from file. 
+read_oni <- function(file) {
+  data <- read.csv(file)
+  data$Date <- as.Date(data$Date)
+  data$Month <- abbr_month(data$Date)
+  data$ONI_month_window <- as.character(data$ONI_month_window)
+  
+  class(data) <- c("tbl_df", "tbl", "data.frame")
+}

--- a/R/download-soi.R
+++ b/R/download-soi.R
@@ -1,6 +1,7 @@
 #' @export
 #' @title Download Southern Oscillation Index data
 #' 
+#' @inheritParams download_oni
 #' 
 #' @description The Southern Oscillation Index is defined as the standardized difference between barometric readings at Darwin, Australia and Tahiti. 
 #' 
@@ -20,15 +21,15 @@
 #' }
 #'
 #' @references \url{https://www.ncdc.noaa.gov/teleconnections/enso/indicators/soi/} 
-
+download_soi <- function(use_cache = FALSE, file = NULL) {
+  with_cache(use_cache = use_cache, file = file, 
+             memoised = download_soi_memoised, 
+             unmemoised = download_soi_unmemoised, 
+             read_function = read_soi)
+}
 
 ## Function to bring in SOI data
-download_soi <- function(){
-  
-  if(!curl::has_internet()){
-    return(message("A working internet connection is required to download and import the climate indices."))
-  }
-  
+download_soi_unmemoised <- function(){
   soi_link = "https://www.ncdc.noaa.gov/teleconnections/enso/indicators/soi/data.csv"
   
   res = check_response(soi_link)
@@ -54,4 +55,15 @@ download_soi <- function(){
   
   soi[,c("Date", "Month", "Year", "SOI", "SOI_3MON_AVG")]
 
+}
+
+download_soi_memoised <- memoise::memoise(download_soi_unmemoised)
+
+read_soi <- function(file) {
+  data <- read.csv(file)
+  data$Date <- as.Date(data$Date)
+  data$Month <- abbr_month(data$Date)
+  
+  class(data) <- c("tbl_df", "tbl", "data.frame")
+  data
 }

--- a/R/download-soi.R
+++ b/R/download-soi.R
@@ -63,7 +63,7 @@ read_soi <- function(file) {
   data <- read.csv(file)
   data$Date <- as.Date(data$Date)
   data$Month <- abbr_month(data$Date)
-  
+  data$Year <- as.character(data$Year)
   class(data) <- c("tbl_df", "tbl", "data.frame")
   data
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,16 +32,17 @@ check_response <- function(link){
 
 
 
-with_cache <- function(cache, file, memoised, unmemoised, 
+with_cache <- function(use_cache, file, memoised, unmemoised, 
                        read_function = read.csv, 
-                       write_function = function(data, file) write.csv(data, file, row.names = FALSE)) {
+                       write_function = function(data, file) write.csv(data, file, row.names = FALSE), 
+                       ...) {
   # cache in memory
-  if (cache && is.null(file)) {
-    return(memoised())
+  if (use_cache && is.null(file)) {
+    return(memoised(...))
   }
   
   # cache in file  
-  if (cache && file.exists(file)) {
+  if (use_cache && file.exists(file)) {
     return(read_function(file))
   }
   
@@ -49,13 +50,13 @@ with_cache <- function(cache, file, memoised, unmemoised,
     message("A working internet connection is required to download and import the climate indices.")
     return(NULL)
   }
-  data <- unmemoised()
+  data <- unmemoised(...)
   
   if (!is.null(file)) { 
     write_function(data, file)
   }
   
-  if (!cache) {
+  if (!use_cache) {
     memoise::forget(memoised)
   } 
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,9 @@ check_response <- function(link){
 
 
 
-with_cache <- function(cache, file, memoised, unmemoised) {
+with_cache <- function(cache, file, memoised, unmemoised, 
+                       read_function = read.csv, 
+                       write_function = function(data, file) write.csv(data, file, row.names = FALSE)) {
   # cache in memory
   if (cache && is.null(file)) {
     return(memoised())
@@ -40,7 +42,7 @@ with_cache <- function(cache, file, memoised, unmemoised) {
   
   # cache in file  
   if (cache && file.exists(file)) {
-    return(suppressMessages(readr::read_csv(file)))
+    return(read_function(file))
   }
   
   if(!curl::has_internet()){
@@ -50,7 +52,7 @@ with_cache <- function(cache, file, memoised, unmemoised) {
   data <- unmemoised()
   
   if (!is.null(file)) { 
-    readr::write_csv(data, file)
+    write_function(data, file)
   }
   
   if (!cache) {
@@ -59,3 +61,5 @@ with_cache <- function(cache, file, memoised, unmemoised) {
   
   return(data)
 }
+
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,3 +29,33 @@ check_response <- function(link){
   
   textConnection(rawToChar(response$content))
 }
+
+
+
+with_cache <- function(cache, file, memoised, unmemoised) {
+  # cache in memory
+  if (cache && is.null(file)) {
+    return(memoised())
+  }
+  
+  # cache in file  
+  if (cache && file.exists(file)) {
+    return(suppressMessages(readr::read_csv(file)))
+  }
+  
+  if(!curl::has_internet()){
+    message("A working internet connection is required to download and import the climate indices.")
+    return(NULL)
+  }
+  data <- unmemoised()
+  
+  if (!is.null(file)) { 
+    readr::write_csv(data, file)
+  }
+  
+  if (!cache) {
+    memoise::forget(memoised)
+  } 
+  
+  return(data)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,7 @@ abbr_month <- function(date){
          levels = levels)
 }
 
-## Check the response from server.
+## Check the response from server.tes
 check_response <- function(link){
   #browser()
   

--- a/man/download_ao.Rd
+++ b/man/download_ao.Rd
@@ -4,7 +4,14 @@
 \alias{download_ao}
 \title{Download North Atlantic Oscillation data}
 \usage{
-download_ao()
+download_ao(use_cache = FALSE, file = NULL)
+}
+\arguments{
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/download_enso.Rd
+++ b/man/download_enso.Rd
@@ -4,8 +4,7 @@
 \alias{download_enso}
 \title{Download Southern Oscillation Index and Oceanic Nino Index data}
 \usage{
-download_enso(climate_idx = c("all", "soi", "oni", "npgo"),
-  create_csv = FALSE)
+download_enso(climate_idx = c("all", "soi", "oni", "npgo"), create_csv = FALSE)
 }
 \arguments{
 \item{climate_idx}{Choose which ENSO related climate index to output. Current arguments supported are soi (the Southern Oscillation Index), oni (the Oceanic Nino Index), npgo (the North Pacific Gyre Oscillation) and all. all outputs each supported index variable as a slimmer dataset than each individual climate index call.}

--- a/man/download_mei.Rd
+++ b/man/download_mei.Rd
@@ -4,7 +4,14 @@
 \alias{download_mei}
 \title{Download Multivariate ENSO Index Version 2 (MEI.v2)}
 \usage{
-download_mei()
+download_mei(use_cache = FALSE, file = NULL)
+}
+\arguments{
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/download_nao.Rd
+++ b/man/download_nao.Rd
@@ -4,7 +4,14 @@
 \alias{download_nao}
 \title{Download North Atlantic Oscillation data}
 \usage{
-download_nao()
+download_nao(use_cache = FALSE, file = NULL)
+}
+\arguments{
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/download_npgo.Rd
+++ b/man/download_npgo.Rd
@@ -4,7 +4,14 @@
 \alias{download_npgo}
 \title{Download North Pacific Gyre Oscillation data}
 \usage{
-download_npgo()
+download_npgo(use_cache = FALSE, file = NULL)
+}
+\arguments{
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/download_oni.Rd
+++ b/man/download_oni.Rd
@@ -4,7 +4,14 @@
 \alias{download_oni}
 \title{Download Oceanic Nino Index data}
 \usage{
-download_oni()
+download_oni(cache = FALSE, file = NULL)
+}
+\arguments{
+\item{cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/download_oni.Rd
+++ b/man/download_oni.Rd
@@ -4,10 +4,10 @@
 \alias{download_oni}
 \title{Download Oceanic Nino Index data}
 \usage{
-download_oni(cache = FALSE, file = NULL)
+download_oni(use_cache = FALSE, file = NULL)
 }
 \arguments{
-\item{cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
 if `file` is `NULL` or on disk if `file` is not `NULL`.}
 
 \item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but

--- a/man/download_soi.Rd
+++ b/man/download_soi.Rd
@@ -4,7 +4,14 @@
 \alias{download_soi}
 \title{Download Southern Oscillation Index data}
 \usage{
-download_soi()
+download_soi(use_cache = FALSE, file = NULL)
+}
+\arguments{
+\item{use_cache}{logical option to save and load from cache. If `TRUE`, results will be cached in memory
+if `file` is `NULL` or on disk if `file` is not `NULL`.}
+
+\item{file}{optional character with the full path of a file to save the data. If `cache` is `FALSE` but
+`file` is not `NULL`, the results will be downloaded from the internet and saved on disk.}
 }
 \value{
 \itemize{

--- a/man/rsoi-package.Rd
+++ b/man/rsoi-package.Rd
@@ -18,7 +18,12 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sam Albers \email{sam.albers@gmail.com} (0000-0002-9270-7884)
+\strong{Maintainer}: Sam Albers \email{sam.albers@gmail.com} (\href{https://orcid.org/0000-0002-9270-7884}{ORCID})
+
+Other contributors:
+\itemize{
+  \item Elio Campitelli \email{elio.campitelli@cima.fcen.uba.ar} (\href{https://orcid.org/0000-0002-7742-9230}{ORCID}) [contributor]
+}
 
 }
 \keyword{internal}

--- a/tests/testthat/test-cache_logic.R
+++ b/tests/testthat/test-cache_logic.R
@@ -1,7 +1,8 @@
 test_function <- function() {
-  tibble::tibble(x = rnorm(100),
+  data.frame(x = rnorm(100),
                  y = rnorm(100))
 }
+
 
 test_function_memoised <- memoise::memoise(test_function)
 
@@ -25,7 +26,7 @@ test_that("doesn't cache by default", {
   
   expect_false(same(res1, res2))
   
-  res_file <- readr::read_csv(file)
+  res_file <- read.csv(file)
   expect_equal(res2, res_file, check.attributes = FALSE)
 })
 

--- a/tests/testthat/test-cache_logic.R
+++ b/tests/testthat/test-cache_logic.R
@@ -1,0 +1,47 @@
+test_function <- function() {
+  tibble::tibble(x = rnorm(100),
+                 y = rnorm(100))
+}
+
+test_function_memoised <- memoise::memoise(test_function)
+
+
+same <- function(x, y) {
+  isTRUE(all.equal(x, y, check.attributes = FALSE))
+}
+
+
+context("cache logic")
+
+test_that("doesn't cache by default", {
+  res1 <- with_cache(cache = FALSE, file = NULL, test_function_memoised, test_function)
+  res2 <- with_cache(cache = FALSE, file = NULL, test_function_memoised, test_function)
+  
+  expect_false(same(res1, res2))
+  
+  file <- tempfile()
+  res1 <- with_cache(cache = FALSE, file = file, test_function_memoised, test_function)
+  res2 <- with_cache(cache = FALSE, file = file, test_function_memoised, test_function)
+  
+  expect_false(same(res1, res2))
+  
+  res_file <- readr::read_csv(file)
+  expect_equal(res2, res_file, check.attributes = FALSE)
+})
+
+
+
+test_that("cache works", {
+  res1 <- with_cache(cache = TRUE, file = NULL, test_function_memoised, test_function)
+  res2 <- with_cache(cache = TRUE, file = NULL, test_function_memoised, test_function)
+  
+  expect_equal(res1, res2, check.attributes = FALSE)
+  file <- tempfile()
+  res3 <- with_cache(cache = TRUE, file = file, test_function_memoised, test_function)
+  res4 <- with_cache(cache = TRUE, file = file, test_function_memoised, test_function)
+  
+  expect_equal(res3, res4, check.attributes = FALSE)
+  
+  expect_false(same(res1, res3))
+  
+})

--- a/tests/testthat/test-cache_logic.R
+++ b/tests/testthat/test-cache_logic.R
@@ -8,21 +8,21 @@ test_function_memoised <- memoise::memoise(test_function)
 
 
 same <- function(x, y) {
-  isTRUE(all.equal(x, y, check.attributes = FALSE))
+  isTRUE(all.equal(x, y))
 }
 
 
 context("cache logic")
 
 test_that("doesn't cache by default", {
-  res1 <- with_cache(cache = FALSE, file = NULL, test_function_memoised, test_function)
-  res2 <- with_cache(cache = FALSE, file = NULL, test_function_memoised, test_function)
+  res1 <- with_cache(use_cache = FALSE, file = NULL, test_function_memoised, test_function)
+  res2 <- with_cache(use_cache = FALSE, file = NULL, test_function_memoised, test_function)
   
   expect_false(same(res1, res2))
   
   file <- tempfile()
-  res1 <- with_cache(cache = FALSE, file = file, test_function_memoised, test_function)
-  res2 <- with_cache(cache = FALSE, file = file, test_function_memoised, test_function)
+  res1 <- with_cache(use_cache = FALSE, file = file, test_function_memoised, test_function)
+  res2 <- with_cache(use_cache = FALSE, file = file, test_function_memoised, test_function)
   
   expect_false(same(res1, res2))
   
@@ -33,13 +33,13 @@ test_that("doesn't cache by default", {
 
 
 test_that("cache works", {
-  res1 <- with_cache(cache = TRUE, file = NULL, test_function_memoised, test_function)
-  res2 <- with_cache(cache = TRUE, file = NULL, test_function_memoised, test_function)
+  res1 <- with_cache(use_cache = TRUE, file = NULL, test_function_memoised, test_function)
+  res2 <- with_cache(use_cache = TRUE, file = NULL, test_function_memoised, test_function)
   
   expect_equal(res1, res2, check.attributes = FALSE)
   file <- tempfile()
-  res3 <- with_cache(cache = TRUE, file = file, test_function_memoised, test_function)
-  res4 <- with_cache(cache = TRUE, file = file, test_function_memoised, test_function)
+  res3 <- with_cache(use_cache = TRUE, file = file, test_function_memoised, test_function)
+  res4 <- with_cache(use_cache = TRUE, file = file, test_function_memoised, test_function)
   
   expect_equal(res3, res4, check.attributes = FALSE)
   

--- a/tests/testthat/test_download_.R
+++ b/tests/testthat/test_download_.R
@@ -21,15 +21,20 @@ sink <- lapply(indexes, test_download)
 context("Read functions recover identical object")
 
 test_read <- function(index) {
-  file <- tempfile()
-  download_fun <- match.fun(paste0("download_", index))
-  
   test_that(paste0("read_", index, " recovers data"), {
+    file <- tempfile()
+    
+    download_fun <- match.fun(paste0("download_", index))
+    # read_fun <- match.fun(paste0("read_", index))
+    read_fun <- get(paste0("read_", index), asNamespace("rsoi"), mode = "function")
+    
     skip_if_no_internet()
     skip_if_shutdown()
     
     data <- download_fun(use_cache = FALSE, file = file)
-    data2 <- download_fun(use_cache = TRUE, file = file)
+    data2 <- read_fun(file)
+    
+    # data2 <- download_fun(use_cache = TRUE, file = file)
     expect_equal(data, data2)
   })
 }

--- a/tests/testthat/test_download_.R
+++ b/tests/testthat/test_download_.R
@@ -2,6 +2,7 @@ indexes <- c("oni", "ao", "nao", "soi", "mei", "npgo")
 
 context("Testing download")
 
+
 test_download <- function(index) {
   function_name <- paste0("download_", index)
   fun <- match.fun(function_name)
@@ -22,18 +23,16 @@ context("Read functions recover identical object")
 test_read <- function(index) {
   file <- tempfile()
   download_fun <- match.fun(paste0("download_", index))
-  read_fun <- match.fun(paste0("read_", index))
   
   test_that(paste0("read_", index, " recovers data"), {
     skip_if_no_internet()
     skip_if_shutdown()
     
-    data <- download_fun()
-    write.csv(data, file, row.names = FALSE)
-    expect_equal(read_fun(file), data)
+    data <- download_fun(use_cache = FALSE, file = file)
+    data2 <- download_fun(use_cache = TRUE, file = file)
+    expect_equal(data, data2)
   })
 }
 
 
 sink <- lapply(indexes, test_read)
-

--- a/tests/testthat/test_download_.R
+++ b/tests/testthat/test_download_.R
@@ -1,42 +1,39 @@
+indexes <- c("oni", "ao", "nao", "soi", "mei", "npgo")
+
 context("Testing download")
 
-test_that("Does download_soi download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_soi(), "data.frame" )
-})
+test_download <- function(index) {
+  function_name <- paste0("download_", index)
+  fun <- match.fun(function_name)
+  
+  test_that(paste0("Does ", function_name, " download a data.frame?"), {
+    skip_if_no_internet()
+    skip_if_shutdown()
+    expect_is( fun, "data.frame" )
+  })
+}
 
 
-test_that("Does download_oni download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_oni(), "data.frame" )
-})
+sink <- lapply(indexes, test_download)
 
 
-test_that("Does download_npgo download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_npgo(), "data.frame" )
-})
+context("Read functions recover identical object")
+
+test_read <- function(index) {
+  file <- tempfile()
+  download_fun <- match.fun(paste0("download_", index))
+  read_fun <- match.fun(paste0("read_", index))
+  
+  test_that(paste0("read_", index, " recovers data"), {
+    skip_if_no_internet()
+    skip_if_shutdown()
+    
+    data <- download_fun()
+    write.csv(data, file, row.names = FALSE)
+    expect_equal(read_fun(file), data)
+  })
+}
 
 
-test_that("Does download_nao download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_nao(), "data.frame" )
-})
+sink <- lapply(indexes, test_read)
 
-
-test_that("Does download_ao download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_ao(), "data.frame" )
-})
-
-
-test_that("Does download_mei download a data.frame?", {
-  skip_if_no_internet()
-  skip_if_shutdown()
-  expect_is( download_mei(), "data.frame" )
-})

--- a/tests/testthat/test_download_.R
+++ b/tests/testthat/test_download_.R
@@ -9,7 +9,7 @@ test_download <- function(index) {
   test_that(paste0("Does ", function_name, " download a data.frame?"), {
     skip_if_no_internet()
     skip_if_shutdown()
-    expect_is( fun, "data.frame" )
+    expect_is( fun(), "data.frame" )
   })
 }
 


### PR DESCRIPTION
This is an incomplete PR addressing #18 that only adds cache to `download_oni()`. I wanted to show you the internals I've came up with before moving forward. 
The core change is that I added an internal function `with_cache()` that has all the logic for caching and downloading to disk. The reason I made this into another function is so that the same exact logic can be applied easily to any other `download_*()` function. 

Usage is relatively simple:
`cache` controls whether results are cached or not; either in memory (if `file` is `NULL`) or in a file, if provided.
`file`, on the other hand, determines whether the results are saved to disk, independently of the value of `cache`.

Let me know what you think. If you're happy with this I'll change the rest of the functions. 