### PR TITLE
Adds `NA` to ONI month window at the extremes.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,5 +9,5 @@
 ^revdep$
 ^README\.Rmd$
 ^README-.*\.png$
-
+^.github$
 docs

--- a/R/download-oni.R
+++ b/R/download-oni.R
@@ -65,6 +65,7 @@ download_oni_unmemoised <- function() {
                                                                substr(oni$Month[x],1,1),
                                                                substr(oni$Month[x+1],1,1),
                                                                sep=""))
+  oni$ONI_month_window[c(1, nrow(oni))] <- NA
   
   ## Assign phase 
   oni$phase = factor(ifelse(oni$ONI <= -0.5,"Cool Phase/La Nina",

--- a/tests/testthat/test-download-oni.R
+++ b/tests/testthat/test-download-oni.R
@@ -1,0 +1,7 @@
+context('testing download_oni')
+
+test_that('the first and last rows of ONI_month_window are NA',{
+  oni <- download_oni()
+  expect_true(is.na(oni$ONI_month_window[1]))
+  expect_true(is.na(oni$ONI_month_window[nrow(oni)]))
+})


### PR DESCRIPTION
The last row of `ONI_month_window` fails because there is no "next month". 

``` r
library(rsoi)
tail(download_oni())
#>           Date Month Year dSST3.4       ONI ONI_month_window
#> 834 2019-06-01   jun 2019    0.54 0.5266667              mjj
#> 835 2019-07-01   jul 2019    0.39 0.3100000              jja
#> 836 2019-08-01   ago 2019    0.00 0.1200000              jas
#> 837 2019-09-01   sep 2019   -0.03 0.1433333              aso
#> 838 2019-10-01   oct 2019    0.46 0.3033333              son
#> 839 2019-11-01   nov 2019    0.48        NA             onNA
#>                  phase
#> 834 Warm Phase/El Nino
#> 835      Neutral Phase
#> 836      Neutral Phase
#> 837      Neutral Phase
#> 838      Neutral Phase
#> 839               <NA>
```

<sup>Created on 2019-12-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR replaces the first and last row of that column with `NA`, which I think is pretty reasonable. 


(Sorry for the rapid fire PRs but you're being victimised by my procrastinating from my actual work 😅️)
