### PR TITLE
accommodate data change

### DIFF
--- a/R/download-nao.R
+++ b/R/download-nao.R
@@ -39,7 +39,8 @@ download_nao_unmemoised <- function(){
   
   nao = read.fwf(nao_link, 
                 widths = c(4, rep(7, 12)),
-                header = FALSE, 
+                header = FALSE,
+                skip = 1, 
                 col.names = c("Year", month.abb))
   
   reshaped_list <- lapply(


### PR DESCRIPTION
Looks like the NAO data has a bit of a format change. Need to now skip one explicitly.